### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # md.md
 # lua:gist
 # $~git@github.com:GistIcon/md.md.git
+[![Code Issues](https://www.quantifiedcode.com/api/v1/project/05d6341ff8134e9ba1abcae3ea6ad6b8/badge.svg)](https://www.quantifiedcode.com/app/project/05d6341ff8134e9ba1abcae3ea6ad6b8)


### PR DESCRIPTION
Set the name which is used in verification of hostname. If SSL_verifycn_scheme is set and no SSL_verifycn_name is given it will try to use SSL_hostname or PeerHost and PeerAddr settings and fail if no name can be determined. If SSL_verifycn_scheme is not set it will use a default scheme and warn if it cannot determine a hostname, but it will not fail.

Using PeerHost or PeerAddr works only if you create the connection directly with IO::Socket::SSL->new, if an IO::Socket::INET object is upgraded with start_SSL the name has to be given in SSL_verifycn_name or SSL_hostname.
