### PR TITLE
Create <=>(other)

### DIFF
--- a/RDoc/Alias.html/<=>(other)
+++ b/RDoc/Alias.html/<=>(other)
@@ -1,0 +1,4 @@
+# File lib/rdoc/alias.rb, line 49
+def <=>(other)
+  [@singleton ? 0 : 1, new_name] <=> [other.singleton ? 0 : 1, other.new_name]
+end


### PR DESCRIPTION
class RDoc::Alias

Represent an alias, which is an old_name/new_name pair associated with a particular context
