### PR TITLE
<=>(other)

### DIFF
--- a/RDoc/Alias.html/<=>(other)
+++ b/RDoc/Alias.html/<=>(other)
@@ -1,0 +1,4 @@
+# File lib/rdoc/alias.rb, line 49
+def <=>(other)
+  [@singleton ? 0 : 1, new_name] <=> [other.singleton ? 0 : 1, other.new_name]
+end


### PR DESCRIPTION
Create <=>(other) …
class RDoc::Alias

Represent an alias, which is an old_name/new_name pair associated with a particular context
 daf301e
 @usernamealreadyis usernamealreadyis   Merge pull request #1 from GistIcon/usernamealreadyis-patch-19 …
Create <=>(other)
