### PR TITLE
people.yml:

### DIFF
--- a/RDoc/_data/people.yml
+++ b/RDoc/_data/people.yml
@@ -1,0 +1,11 @@
+---
+title: sample post
+author: GistIcon
+---
+
+{% assign author = site.data.people[page.author] %}
+<a rel="author"
+  href="{{ author.twitter }}"
+  title="{{ author.name }}">
+    {{ author.name }}
+</a>


### PR DESCRIPTION
Example: Accessing a specific authorPermalink

Pages and posts can also access a specific data item. The example below shows how to access a specific item:

_data/`people.yml:`
