### PR TITLE
manifest.json

### DIFF
--- a/md/usr/bin/manifest.json
+++ b/md/usr/bin/manifest.json
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Cache-Control: max-age=31536000
+Content-Type: application/manifest+json
+
+{
+  "lang": "en",
+  "name": "GistIcon",
+  "start_url": "/start.html",
+  "display": "fullscreen",
+  "orientation": "landscape"
+}


### PR DESCRIPTION
Authors are encouraged to use the HTTP cache directives to explicitly cache the manifest. For [example](https://www.w3.org/TR/appmanifest/#dfn-manifest), the following response would cause a cached manifest to be used one year from the time the response is sent:
