### PR TITLE
 Impacted code looks

### DIFF
--- a/GET/repos/owner/repo/.js
+++ b/GET/repos/owner/repo/.js
@@ -1,0 +1,48 @@
+/*
+ * [TestHexLiterals.java]
+ *
+ * Summary: Demonstrate how to use hex literals in Java.
+ *
+ * Copyright: (c) 2013-2016 Roedy Green, Canadian Mind Products, http://mindprod.com
+ *
+ * Licence: This software may be copied and used freely for any purpose but military.
+ *          http://mindprod.com/contact/nonmil.html
+ *
+ * Requires: JDK 1.8+
+ *
+ * Created with: JetBrains IntelliJ IDEA IDE http://www.jetbrains.com/idea/
+ *
+ * Version History:
+ *  1.0 2013-01-05 initial version.
+ */
+package com.mindprod.example;
+
+import static java.lang.System.*;
+
+/**
+ * Demonstrate how to use hex literals in Java.
+ *
+ * @author Roedy Green, Canadian Mind Products
+ * @version 1.0 2013-01-05 initial version.
+ * @since 2013-01-05
+ */
+public final class TestHexLiterals
+    {
+    /**
+     * Test harness
+     *
+     * @param args not used
+     */
+    public static void main( String[] args )
+        {
+        byte b = ( byte ) 0x20;
+        char c = '\u00c9';
+        short s = ( short ) 0x0fab;
+        int i = 0xffab;
+        long l = 0xffabL;
+        float f = 0x1.0abcdefp3F;  // p3 means times 8 i.e. 2 to the power 3
+        double d = 0x1.0abcdefp3D;
+        out.println( b + " " + c + " " + s + " " + i + " " + l + " " + f + " " + d );
+        // displays 32 É 4011 65451 65451 8.335555 8.335555523633957
+        }
+    }

--- a/md/root/test/ruby/handle.rb
+++ b/md/root/test/ruby/handle.rb
@@ -1,0 +1,2 @@
+handle = Fiddle::Handle.new(some_library)
+function_pointer = handle[dangerous_user_input]


### PR DESCRIPTION
There is an unsafe tainted string vulnerability in Fiddle and DL. This issue was originally reported and fixed with [CVE-2009-5147](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-5147) in DL, but reappeared after DL was reimplemented using Fiddle and libffi.

And, about DL, [CVE-2009-5147](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-5147) was fixed at Ruby 1.9.1, but not fixed at other branches, then rubies which bundled DL except Ruby 1.9.1 are still vulnerable.

Impacted code looks something like this: @AndisthermalFindLasthree  assignee #156 
