### PR TITLE
request #33

### DIFF
--- a/md/root/test/ruby/Library/class::Filddle.rb
+++ b/md/root/test/ruby/Library/class::Filddle.rb
@@ -1,0 +1,76 @@
+**// new(lib = nil, flags = Fiddle::RTLD_LAZY | Fiddle::RTLD_GLOBAL)
+**// Create a new handler that opens library named lib with flags. If no library is specified, RTLD_DEFAULT is used
+
+               static VALUE
+rb_fiddle_handle_initialize(int argc, VALUE argv[], VALUE self)
+{
+    void *ptr;
+    struct dl_handle *fiddle_handle;
+    VALUE lib, flag;
+    char  *clib;
+    int   cflag;
+    const char *err;
+
+    switch( rb_scan_args(argc, argv, "02", &lib, &flag) ){
+      case 0:
+        clib = NULL;
+        cflag = RTLD_LAZY | RTLD_GLOBAL;
+        break;
+      case 1:
+        clib = NIL_P(lib) ? NULL : SafeStringValueCStr(lib);
+        cflag = RTLD_LAZY | RTLD_GLOBAL;
+        break;
+      case 2:
+        clib = NIL_P(lib) ? NULL : SafeStringValueCStr(lib);
+        cflag = NUM2INT(flag);
+        break;
+      default:
+        rb_bug("rb_fiddle_handle_new");
+    }
+
+    rb_secure(2);
+
+#if defined(_WIN32)
+    if( !clib ){
+        HANDLE rb_libruby_handle(void);
+        ptr = rb_libruby_handle();
+    }
+    else if( STRCASECMP(clib, "libc") == 0
+# ifdef RUBY_COREDLL
+             || STRCASECMP(clib, RUBY_COREDLL) == 0
+             || STRCASECMP(clib, RUBY_COREDLL".dll") == 0
+# endif
+        ){
+# ifdef _WIN32_WCE
+        ptr = dlopen("coredll.dll", cflag);
+# else
+        ptr = w32_coredll();
+# endif
+    }
+    else
+#endif
+        ptr = dlopen(clib, cflag);
+#if defined(HAVE_DLERROR)
+    if( !ptr && (err = dlerror()) ){
+        rb_raise(rb_eFiddleError, "%s", err);
+    }
+#else
+    if( !ptr ){
+        err = dlerror();
+        rb_raise(rb_eFiddleError, "%s", err);
+    }
+#endif
+    TypedData_Get_Struct(self, struct dl_handle, &fiddle_handle_data_type, fiddle_handle);
+    if( fiddle_handle->ptr && fiddle_handle->open && fiddle_handle->enable_close ){
+        dlclose(fiddle_handle->ptr);
+    }
+    fiddle_handle->ptr = ptr;
+    fiddle_handle->open = 1;
+    fiddle_handle->enable_close = 0;
+
+    if( rb_block_given_p() ){
+        rb_ensure(rb_yield, self, rb_fiddle_handle_close, self);
+    }
+
+    return Qnil;
+}


### PR DESCRIPTION
Fiddle::Handle

The "fiddle" pattern had its origins in France about 1675, but is not found in English silver until a century later. Its handle's shape resembles a fiddle (violin) with the stem like a finger-board and the body with smooth parallel sides extending towards a rounded terminal.
This pattern was also very common in American coin silver, was highly popular in the early part of the 19th century and generally replaced the Old English as the most popular pattern.
The fiddle pattern has many variants:
- fiddle thread, whith a border motif of one or two thin closely spaced lines along the entire lenght of both edges of the stem
- fiddle shell, with a relief shell at the terminal of the handle
- fiddle thread and shell, combining the preceding two forms
  fix: #34 :: #32  
  precess: @GistIcon/bola fix: #136 
