### PR TITLE
openssl

### DIFF
--- a/usr/bin/openssl
+++ b/usr/bin/openssl
@@ -1,0 +1,2 @@
+$ which openssl
+/usr/bin/openssl


### PR DESCRIPTION
Prerequisites
The openssl library is required to generate your own certificate. Run the following command in your local environment to see if you already have openssl installed installed.
